### PR TITLE
Fix startdate and enddate filter processing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,105 +1,105 @@
 {
   "name": "d2l-cpd",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-      "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+      "version": "7.10.3",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.3.tgz",
+      "integrity": "sha512-fDx9eNW0qz0WkUeqL6tXEXzVlPh6Y5aCDEZesl0xBGA8ndRukX91Uk44ZqnkECp01NAZUdCAl+aiQNGi0k88Eg==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.8.3"
+        "@babel/highlight": "^7.10.3"
       }
     },
     "@babel/generator": {
-      "version": "7.9.6",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.6.tgz",
-      "integrity": "sha512-+htwWKJbH2bL72HRluF8zumBxzuX0ZZUFl3JLNyoUjM/Ho8wnVpPXM6aUz8cfKDqQ/h7zHqKt4xzJteUosckqQ==",
+      "version": "7.10.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.3.tgz",
+      "integrity": "sha512-drt8MUHbEqRzNR0xnF8nMehbY11b1SDkRw03PSNH/3Rb2Z35oxkddVSi3rcaak0YJQ86PCuE7Qx1jSFhbLNBMA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.9.6",
+        "@babel/types": "^7.10.3",
         "jsesc": "^2.5.1",
         "lodash": "^4.17.13",
         "source-map": "^0.5.0"
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.9.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
-      "integrity": "sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==",
+      "version": "7.10.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.3.tgz",
+      "integrity": "sha512-FvSj2aiOd8zbeqijjgqdMDSyxsGHaMt5Tr0XjQsGKHD3/1FP3wksjnLAWzxw7lvXiej8W1Jt47SKTZ6upQNiRw==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.8.3",
-        "@babel/template": "^7.8.3",
-        "@babel/types": "^7.9.5"
+        "@babel/helper-get-function-arity": "^7.10.3",
+        "@babel/template": "^7.10.3",
+        "@babel/types": "^7.10.3"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
-      "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+      "version": "7.10.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.3.tgz",
+      "integrity": "sha512-iUD/gFsR+M6uiy69JA6fzM5seno8oE85IYZdbVVEuQaZlEzMO2MXblh+KSPJgsZAUx0EEbWXU0yJaW7C9CdAVg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.8.3"
+        "@babel/types": "^7.10.3"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
-      "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.1.tgz",
+      "integrity": "sha512-UQ1LVBPrYdbchNhLwj6fetj46BcFwfS4NllJo/1aJsT+1dLTEnXJL0qHqtY7gPzF8S2fXBJamf1biAXV3X077g==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.8.3"
+        "@babel/types": "^7.10.1"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.9.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
-      "integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==",
+      "version": "7.10.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.3.tgz",
+      "integrity": "sha512-bU8JvtlYpJSBPuj1VUmKpFGaDZuLxASky3LhaKj3bmpSTY6VWooSM8msk+Z0CZoErFye2tlABF6yDkT3FOPAXw==",
       "dev": true
     },
     "@babel/highlight": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
-      "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
+      "version": "7.10.3",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.3.tgz",
+      "integrity": "sha512-Ih9B/u7AtgEnySE2L2F0Xm0GaM729XqqLfHkalTsbjXGyqmf/6M0Cu0WpvqueUlW+xk88BHw9Nkpj49naU+vWw==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.9.0",
+        "@babel/helper-validator-identifier": "^7.10.3",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       }
     },
     "@babel/parser": {
-      "version": "7.9.6",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.6.tgz",
-      "integrity": "sha512-AoeIEJn8vt+d/6+PXDRPaksYhnlbMIiejioBZvvMQsOjW/JYK6k/0dKnvvP3EhK5GfMBWDPtrxRtegWdAcdq9Q==",
+      "version": "7.10.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.3.tgz",
+      "integrity": "sha512-oJtNJCMFdIMwXGmx+KxuaD7i3b8uS7TTFYW/FNG2BT8m+fmGHoiPYoH0Pe3gya07WuFmM5FCDIr1x0irkD/hyA==",
       "dev": true
     },
     "@babel/template": {
-      "version": "7.8.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
-      "integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
+      "version": "7.10.3",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.3.tgz",
+      "integrity": "sha512-5BjI4gdtD+9fHZUsaxPHPNpwa+xRkDO7c7JbhYn2afvrkDu5SfAAbi9AIMXw2xEhO/BR35TqiW97IqNvCo/GqA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.8.3",
-        "@babel/parser": "^7.8.6",
-        "@babel/types": "^7.8.6"
+        "@babel/code-frame": "^7.10.3",
+        "@babel/parser": "^7.10.3",
+        "@babel/types": "^7.10.3"
       }
     },
     "@babel/traverse": {
-      "version": "7.9.6",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.6.tgz",
-      "integrity": "sha512-b3rAHSjbxy6VEAvlxM8OV/0X4XrG72zoxme6q1MOoe2vd0bEc+TwayhuC1+Dfgqh1QEG+pj7atQqvUprHIccsg==",
+      "version": "7.10.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.3.tgz",
+      "integrity": "sha512-qO6623eBFhuPm0TmmrUFMT1FulCmsSeJuVGhiLodk2raUDFhhTECLd9E9jC4LBIWziqt4wgF6KuXE4d+Jz9yug==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.8.3",
-        "@babel/generator": "^7.9.6",
-        "@babel/helper-function-name": "^7.9.5",
-        "@babel/helper-split-export-declaration": "^7.8.3",
-        "@babel/parser": "^7.9.6",
-        "@babel/types": "^7.9.6",
+        "@babel/code-frame": "^7.10.3",
+        "@babel/generator": "^7.10.3",
+        "@babel/helper-function-name": "^7.10.3",
+        "@babel/helper-split-export-declaration": "^7.10.1",
+        "@babel/parser": "^7.10.3",
+        "@babel/types": "^7.10.3",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.13"
@@ -117,12 +117,12 @@
       }
     },
     "@babel/types": {
-      "version": "7.9.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.6.tgz",
-      "integrity": "sha512-qxXzvBO//jO9ZnoasKF1uJzHd2+M6Q2ZPIVfnFps8JJvXy0ZBbwbNOmE6SGIY5XOY6d1Bo5lb9d9RJ8nv3WSeA==",
+      "version": "7.10.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.3.tgz",
+      "integrity": "sha512-nZxaJhBXBQ8HVoIcGsf9qWep3Oh3jCENK54V4mRF7qaJabVsAYdbTtmSD8WmAp1R6ytPiu5apMwSXyxB1WlaBA==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.9.5",
+        "@babel/helper-validator-identifier": "^7.10.3",
         "lodash": "^4.17.13",
         "to-fast-properties": "^2.0.0"
       }
@@ -155,12 +155,13 @@
       }
     },
     "@brightspace-ui/core": {
-      "version": "1.43.10",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.43.10.tgz",
-      "integrity": "sha512-T5FXE9Qnx9FF6ojyPZT0zGZ6WAYnLkP4dr82tOkxXBKla09BSnA6zUFXpOy+qcJnv6kZuJY7Wfb1ceZmUte/Dw==",
+      "version": "1.56.2",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.56.2.tgz",
+      "integrity": "sha512-aLmExGlZ8b1dpP2fW1ZkehWk/OnO9w1ykrAyRnCoyHqwkAOvUgnUVbpd4bFKS5X3xRCvtAZWcYvdY4E8V5IYCw==",
       "requires": {
         "@brightspace-ui/intl": "^3",
         "@formatjs/intl-pluralrules": "^1",
+        "@open-wc/dedupe-mixin": "^1.2.17",
         "@webcomponents/shadycss": "^1",
         "@webcomponents/webcomponentsjs": "^2",
         "intl-messageformat": "^7",
@@ -170,30 +171,35 @@
       }
     },
     "@brightspace-ui/intl": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/intl/-/intl-3.0.8.tgz",
-      "integrity": "sha512-mstURrd8MYKEOjOG3tDiemmHS9iOc4Yr33Ojh39qFYbeMeD1OKuDvQokLuhz10eukUt1pdfu1aqy5zrO98qErA=="
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/intl/-/intl-3.0.9.tgz",
+      "integrity": "sha512-fvVkfLKDdff1IrQPBnE6GyPgSS+IQ/n0lH/0Fp9/qwi1NqtQNVikXaFNnSc4M7vmLUBmQzh/VBzVWxDLjOYnEA=="
     },
     "@formatjs/intl-pluralrules": {
-      "version": "1.5.8",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-pluralrules/-/intl-pluralrules-1.5.8.tgz",
-      "integrity": "sha512-OtL/rgKSSGljpxk2lRUC92ZqmzZjabwXO5zbBh2Bj8OM+z4U3H1Q5iK+ZY4k7a6EAoY7hWCr3F4k7EL8tcnQow==",
+      "version": "1.5.9",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-pluralrules/-/intl-pluralrules-1.5.9.tgz",
+      "integrity": "sha512-37E1ZG+Oqo3qrpUfumzNcFTV+V+NCExmTkkQ9Zw4FSlvJ4WhbbeYdieVapUVz9M0cLy8XrhCkfuM/Kn03iKReg==",
       "requires": {
-        "@formatjs/intl-utils": "^2.2.5"
+        "@formatjs/intl-utils": "^2.3.0"
       }
     },
     "@formatjs/intl-unified-numberformat": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-unified-numberformat/-/intl-unified-numberformat-3.3.6.tgz",
-      "integrity": "sha512-VQYswh9Pxf4kN6FQvKprAQwSJrF93eJstCDPM1HIt3c3O6NqPFWNWhZ91PLTppOV11rLYsFK11ZxiGbnLNiPTg==",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-unified-numberformat/-/intl-unified-numberformat-3.3.7.tgz",
+      "integrity": "sha512-KnWgLRHzCAgT9eyt3OS34RHoyD7dPDYhRcuKn+/6Kv2knDF8Im43J6vlSW6Hm1w63fNq3ZIT1cFk7RuVO3Psag==",
       "requires": {
-        "@formatjs/intl-utils": "^2.2.5"
+        "@formatjs/intl-utils": "^2.3.0"
       }
     },
     "@formatjs/intl-utils": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-2.2.5.tgz",
-      "integrity": "sha512-p7gcmazKROteL4IECCp03Qrs790fZ8tbemUAjQu0+K0AaAlK49rI1SIFFq3LzDUAqXIshV95JJhRe/yXxkal5g=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-2.3.0.tgz",
+      "integrity": "sha512-KWk80UPIzPmUg+P0rKh6TqspRw0G6eux1PuJr+zz47ftMaZ9QDwbGzHZbtzWkl5hgayM/qrKRutllRC7D/vVXQ=="
+    },
+    "@open-wc/dedupe-mixin": {
+      "version": "1.2.17",
+      "resolved": "https://registry.npmjs.org/@open-wc/dedupe-mixin/-/dedupe-mixin-1.2.17.tgz",
+      "integrity": "sha512-9A3WohqNxEloJa4y1DuBL5zH12cNRNW1vsrkiaLMnOGuQdhibs2XY1oliudsKpvIeNjDXRVRPUdIIzn65BypCw=="
     },
     "@polymer/iron-ajax": {
       "version": "3.0.1",
@@ -232,9 +238,9 @@
       "dev": true
     },
     "@webcomponents/shadycss": {
-      "version": "1.9.6",
-      "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.9.6.tgz",
-      "integrity": "sha512-5fFjvP0jQJZoXK6YzYeYcIDGJ5oEsdjr1L9VaYLw5yxNd4aRz4srMpwCwldeNG0A6Hvr9igbG7fCsBeiiCXd7A=="
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.10.0.tgz",
+      "integrity": "sha512-UMS+dF4DXDrcUmQqK6aLd/3mFyfGktKG/hZR6FtrsQK/INO07G0H8FxElLkuvHj0iePeZGpR7R4lWFTvX7rc9g=="
     },
     "@webcomponents/webcomponentsjs": {
       "version": "2.4.3",
@@ -252,9 +258,9 @@
       }
     },
     "acorn": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
-      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
+      "integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==",
       "dev": true
     },
     "acorn-jsx": {
@@ -412,12 +418,12 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "aws-sdk": {
-      "version": "2.671.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.671.0.tgz",
-      "integrity": "sha512-i83+/TIOLlhAxvV2xVLz5+XGtNqJgQJwP/e8J49rzDkyMV6OE2FgxU8utujGrComrSJFpITqMFqug+ZfdHoLIQ==",
+      "version": "2.706.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.706.0.tgz",
+      "integrity": "sha512-7GT+yrB5Wb/zOReRdv/Pzkb2Qt+hz6B/8FGMVaoysX3NryHvQUdz7EQWi5yhg9CxOjKxdw5lFwYSs69YlSp1KA==",
       "dev": true,
       "requires": {
-        "buffer": "4.9.1",
+        "buffer": "4.9.2",
         "events": "1.1.1",
         "ieee754": "1.1.13",
         "jmespath": "0.15.0",
@@ -443,9 +449,9 @@
       "dev": true
     },
     "axe-core": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.3.tgz",
-      "integrity": "sha512-HZpLE7xu05+8AbpqXITGdxp1Xwk8ysAXrg7MiKRY27py3DAyEJpoJQo1727pWF3F+O79V3r+cTWhOzfB49P89w==",
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.5.tgz",
+      "integrity": "sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q==",
       "dev": true
     },
     "babel-eslint": {
@@ -475,9 +481,9 @@
       "dev": true
     },
     "binary-extensions": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
-      "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
+      "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "dev": true
     },
     "bindings": {
@@ -600,9 +606,9 @@
       "dev": true
     },
     "buffer": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
       "dev": true,
       "requires": {
         "base64-js": "^1.0.2",
@@ -1023,7 +1029,7 @@
       }
     },
     "d2l-localize-behavior": {
-      "version": "github:BrightspaceUI/localize-behavior#3257e7533197d29636eaf43be599f054df0fbd46",
+      "version": "github:BrightspaceUI/localize-behavior#ff9514e84470665348ccbb8584c32b5f51abf13b",
       "from": "github:BrightspaceUI/localize-behavior#semver:^2",
       "requires": {
         "@brightspace-ui/intl": "^3",
@@ -1104,9 +1110,9 @@
       }
     },
     "dayjs": {
-      "version": "1.8.26",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.8.26.tgz",
-      "integrity": "sha512-KqtAuIfdNfZR5sJY1Dixr2Is4ZvcCqhb0dZpCOt5dGEFiMzoIbjkTSzUb4QKTCsP+WNpGwUjAFIZrnZvUxxkhw=="
+      "version": "1.8.28",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.8.28.tgz",
+      "integrity": "sha512-ccnYgKC0/hPSGXxj7Ju6AV/BP4HUkXC2u15mikXT5mX9YorEaoi1bEKOmAqdkJHN4EEkmAf97SpH66Try5Mbeg=="
     },
     "deasync": {
       "version": "0.1.20",
@@ -1220,9 +1226,9 @@
       }
     },
     "domutils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.0.0.tgz",
-      "integrity": "sha512-n5SelJ1axbO636c2yUtOGia/IcJtVtlhQbFiVDBZHKV5ReJO1ViX7sFEemtuyoAnBxk5meNSYgA8V4s0271efg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.1.0.tgz",
+      "integrity": "sha512-CD9M0Dm1iaHfQ1R/TI+z3/JWp/pgub0j4jIQKH89ARR4ATAV2nbaOQS5XxU9maJP5jHaPdDDQSEHuE2UmpUTKg==",
       "dev": true,
       "requires": {
         "dom-serializer": "^0.2.1",
@@ -1270,9 +1276,9 @@
       }
     },
     "entities": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
-      "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
+      "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
       "dev": true
     },
     "error-ex": {
@@ -1285,22 +1291,22 @@
       }
     },
     "es-abstract": {
-      "version": "1.17.5",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
-      "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+      "version": "1.17.6",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+      "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1",
-        "is-callable": "^1.1.5",
-        "is-regex": "^1.0.5",
+        "is-callable": "^1.2.0",
+        "is-regex": "^1.1.0",
         "object-inspect": "^1.7.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.0",
-        "string.prototype.trimleft": "^2.1.1",
-        "string.prototype.trimright": "^2.1.1"
+        "string.prototype.trimend": "^1.0.1",
+        "string.prototype.trimstart": "^1.0.1"
       }
     },
     "es-to-primitive": {
@@ -1660,9 +1666,9 @@
       "dev": true
     },
     "eslint-scope": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
-      "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
+      "integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
       "dev": true,
       "requires": {
         "esrecurse": "^4.1.0",
@@ -1679,9 +1685,9 @@
       }
     },
     "eslint-visitor-keys": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
       "dev": true
     },
     "esm": {
@@ -1892,9 +1898,9 @@
       }
     },
     "fast-deep-equal": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
     "fast-json-stable-stringify": {
@@ -2146,9 +2152,9 @@
       }
     },
     "frau-ci": {
-      "version": "1.41.0",
-      "resolved": "https://registry.npmjs.org/frau-ci/-/frau-ci-1.41.0.tgz",
-      "integrity": "sha512-79dxX0mGuRQtDpOtE13MzQpbDAmOeqWlUzy3fxDCjyVi2W8j87CUgdTbIQ9BQ+XxyLmpmwdoPs5SH5xxQ2OgxQ==",
+      "version": "1.42.1",
+      "resolved": "https://registry.npmjs.org/frau-ci/-/frau-ci-1.42.1.tgz",
+      "integrity": "sha512-EdyKbjSJ9o77KUZyPsyRJj0k3sHJ3HWbbelzT54bs5auwxbMYiHmKa2t4A9MnFurnBrV+HvrvqIT+enAv3/4Ng==",
       "dev": true,
       "requires": {
         "frau-publisher": "^2.5.3",
@@ -2415,9 +2421,9 @@
       }
     },
     "frau-publisher": {
-      "version": "2.7.12",
-      "resolved": "https://registry.npmjs.org/frau-publisher/-/frau-publisher-2.7.12.tgz",
-      "integrity": "sha512-UBcrPHrR217N/5bc/L/MCKn+JSUe46KrtnqnW8JWyU4h+JFhrCijAfrwYIPgXkbFAclwA4KxhywMcWNj0QzmIA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/frau-publisher/-/frau-publisher-2.8.0.tgz",
+      "integrity": "sha512-bkjFeb0d10AvJWd/eaIBbsEum3VADcVJrhE/6LiARdmhdhQJ9yPhTwU8BVujU11abUU+8EbrC5dJwbHend3TdA==",
       "dev": true,
       "requires": {
         "aws-sdk": "^2",
@@ -2427,6 +2433,7 @@
         "pump": "^3",
         "semver": "^7",
         "through2-concurrent": "^2",
+        "vinyl": "^2.2.0",
         "vinyl-fs": "^3",
         "yargs": "^15"
       },
@@ -2833,9 +2840,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "inquirer": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
-      "integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.2.0.tgz",
+      "integrity": "sha512-E0c4rPwr9ByePfNlTIB8z51kK1s2n6jrHuJeEHENl/sbq2G/S1auvibgEwNR4uSyiU+PiYHqSwsgGiXjG8p5ZQ==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^4.2.1",
@@ -2915,9 +2922,9 @@
       }
     },
     "intl-format-cache": {
-      "version": "4.2.27",
-      "resolved": "https://registry.npmjs.org/intl-format-cache/-/intl-format-cache-4.2.27.tgz",
-      "integrity": "sha512-blHXX9qBp8H6fGhQc0jHGh7j97HF0megj4rIB878iazMBdFk/tR7b3av0PJxE72TP8MycLFpeXW9vLY5cBmF4A=="
+      "version": "4.2.42",
+      "resolved": "https://registry.npmjs.org/intl-format-cache/-/intl-format-cache-4.2.42.tgz",
+      "integrity": "sha512-NJldCapugigFv1yAyqsY8jDdHFIJU427Ko47xf4yg2qLj4TtBA0d9lwqFnP5s9WOLJoNP/4ddu85B3ix0c5R7Q=="
     },
     "intl-messageformat": {
       "version": "7.8.4",
@@ -3002,9 +3009,9 @@
       "dev": true
     },
     "is-callable": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-      "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
+      "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
       "dev": true
     },
     "is-date-object": {
@@ -3047,12 +3054,12 @@
       "dev": true
     },
     "is-regex": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
-      "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
+      "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
       "dev": true,
       "requires": {
-        "has": "^1.0.3"
+        "has-symbols": "^1.0.1"
       }
     },
     "is-relative": {
@@ -3136,9 +3143,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -3472,6 +3479,16 @@
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
+        "js-yaml": {
+          "version": "3.13.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+          "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
         "locate-path": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -3630,9 +3647,9 @@
       "dev": true
     },
     "node-addon-api": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.1.tgz",
-      "integrity": "sha512-2+DuKodWvwRTrCfKOeR24KIc5unKjOh8mz17NCzVnHWfjAdDqbfbjqh7gUT+BkXBRQM52+xCHciKWonJ3CbJMQ==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
+      "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
       "dev": true
     },
     "node-environment-flags": {
@@ -3786,9 +3803,9 @@
       "dev": true
     },
     "object-inspect": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
+      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
       "dev": true
     },
     "object-keys": {
@@ -3854,9 +3871,9 @@
       },
       "dependencies": {
         "cross-spawn": {
-          "version": "7.0.2",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.2.tgz",
-          "integrity": "sha512-PD6G8QG3S4FK/XCGFbEQrDqO2AnMMsy0meR7lerlIOHAAbkuavGU/pOqprrlvfTNjvowivTeBsjebAL0NSoMxw==",
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
           "dev": true,
           "requires": {
             "path-key": "^3.1.0",
@@ -3871,9 +3888,9 @@
           "dev": true
         },
         "ignore": {
-          "version": "5.1.4",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
-          "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+          "version": "5.1.8",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+          "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
           "dev": true
         },
         "path-key": {
@@ -18321,9 +18338,9 @@
           }
         },
         "mime": {
-          "version": "2.4.5",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.5.tgz",
-          "integrity": "sha512-3hQhEUF027BuxZjQA3s7rIv/7VCQPa27hN9u9g87sEkWaKwQPuXOkVKtOeiyUrnWqTDiOs8Ed2rwg733mB0R5w==",
+          "version": "2.4.6",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
           "dev": true
         }
       }
@@ -18792,9 +18809,9 @@
       "dev": true
     },
     "spdx-correct": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
-      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
       "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
@@ -18808,9 +18825,9 @@
       "dev": true
     },
     "spdx-expression-parse": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
       "dev": true,
       "requires": {
         "spdx-exceptions": "^2.1.0",
@@ -18891,28 +18908,6 @@
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
-      }
-    },
-    "string.prototype.trimleft": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
-      "integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5",
-        "string.prototype.trimstart": "^1.0.0"
-      }
-    },
-    "string.prototype.trimright": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
-      "integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5",
-        "string.prototype.trimend": "^1.0.0"
       }
     },
     "string.prototype.trimstart": {
@@ -19157,9 +19152,9 @@
       "dev": true
     },
     "tslib": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.2.tgz",
-      "integrity": "sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
       "dev": true
     },
     "tunnel-agent": {
@@ -19283,9 +19278,9 @@
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "v8-compile-cache": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
-      "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
+      "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
       "dev": true
     },
     "validate-npm-package-license": {

--- a/src/services/cpd-service.js
+++ b/src/services/cpd-service.js
@@ -159,8 +159,8 @@ export class CpdService {
 		if (filters) {
 			const { Name, StartDate, EndDate, Dismissed } = filters;
 			if (Name && Name.value) searchParams.append('awardName', Name.value);
-			if (StartDate && StartDate.value) searchParams.append('startDate', dateParamString(StartDate.value));
-			if (EndDate && EndDate.value) searchParams.append('endDate', dateParamString(EndDate.value, true));
+			if (StartDate) searchParams.append('startDate', dateParamString(StartDate));
+			if (EndDate) searchParams.append('endDate', dateParamString(EndDate, true));
 			if (Dismissed) searchParams.append('dismissed', true);
 		}
 		url = url.concat(`?${searchParams.toString()}`);
@@ -175,8 +175,8 @@ export class CpdService {
 			if (Subject && Subject.value && Subject.enabled) searchParams.append('subject', Subject.value);
 			if (Method && Method.value && Method.enabled) searchParams.append('method', Method.value);
 			if (Name && Name.value) searchParams.append('recordName', Name.value);
-			if (StartDate && StartDate.value) searchParams.append('startDate', dateParamString(StartDate.value));
-			if (EndDate && EndDate.value) searchParams.append('endDate', dateParamString(EndDate.value, true));
+			if (StartDate) searchParams.append('startDate', dateParamString(StartDate));
+			if (EndDate) searchParams.append('endDate', dateParamString(EndDate, true));
 			url = url.concat(`?${searchParams.toString()}`);
 		}
 		return this.getRequest(url);
@@ -212,8 +212,8 @@ export class CpdService {
 			if (Subject && Subject.value && Subject.enabled) searchParams.append('subject', Subject.value);
 			if (Method && Method.value && Method.enabled) searchParams.append('method', Method.value);
 			if (Name && Name.value) searchParams.append('recordName', Name.value);
-			if (StartDate && StartDate !== '') searchParams.append('startDate', dateParamString(StartDate.value));
-			if (EndDate && EndDate !== '') searchParams.append('endDate', dateParamString(EndDate.value, true));
+			if (StartDate) searchParams.append('startDate', dateParamString(StartDate));
+			if (EndDate) searchParams.append('endDate', dateParamString(EndDate, true));
 		}
 
 		url = url.concat(`?${searchParams.toString()}`);
@@ -246,8 +246,8 @@ export class CpdService {
 			if (Subject && Subject.value) searchParams.append('subject', Subject.value);
 			if (Method && Method.value) searchParams.append('method', Method.value);
 			if (Name && Name.value) searchParams.append('recordName', Name.value);
-			if (StartDate && StartDate.value) searchParams.append('startDate', StartDate.value);
-			if (EndDate && EndDate.value) searchParams.append('endDate', EndDate.value);
+			if (StartDate) searchParams.append('startDate', StartDate);
+			if (EndDate) searchParams.append('endDate', EndDate);
 			url = url.concat(`?${searchParams.toString()}`);
 		}
 		return this.getRequest(url);
@@ -307,8 +307,8 @@ export class CpdService {
 			if (Subject && Subject.value && Subject.enabled) searchParams.append('subject', Subject.value);
 			if (Method && Method.value && Method.enabled) searchParams.append('method', Method.value);
 			if (Name && Name.value) searchParams.append('recordName', Name.value);
-			if (StartDate && StartDate.value) searchParams.append('startDate', dateParamString(StartDate.value));
-			if (EndDate && EndDate.value) searchParams.append('endDate', dateParamString(EndDate.value, true));
+			if (StartDate) searchParams.append('startDate', dateParamString(StartDate));
+			if (EndDate) searchParams.append('endDate', dateParamString(EndDate, true));
 			url = url.concat(`?${searchParams.toString()}`);
 		}
 		return `${CpdRoutes.Host}${url}`;


### PR DESCRIPTION
Well that's embarrassing. I forgot that the format for StartDate and EndDate change event is different for the new date picker and didn't update the service to accommodate that. So it was always getting essentially blank dates. 
For the new date picker we just pass the chosen value instead of the detail of the event (since it's no longer using a custom event, rather the browser-native change event).