### PR TITLE
Passing just the date string instead of an object containing it

### DIFF
--- a/src/components/cpd-record-report.js
+++ b/src/components/cpd-record-report.js
@@ -181,8 +181,8 @@ class CpdRecordReport extends BaseMixin(LitElement) {
 			Subject: {value: this.subject, enabled: true},
 			Method: {value: this.method, enabled: true},
 			Name: {value: this.recordName},
-			StartDate: {value: this.startDate},
-			EndDate: {value: this.endDate}
+			StartDate: this.startDate,
+			EndDate: this.endDate
 		};
 
 		this.cpdService.getUserInfo(this.userId)


### PR DESCRIPTION
This worked locally, but once transpiled by BSI it would fail. It seems like it should be failing regardless, I'm not sure why it's not.