### PR TITLE
Add novalidate to d2l-input-text

### DIFF
--- a/src/components/cpd-add-record.js
+++ b/src/components/cpd-add-record.js
@@ -261,7 +261,7 @@ class AddCpdRecord extends BaseMixin(LitElement) {
 				<ul>
 					<li>
 						<label for="recordName" class="d2l-label-text">${this.localize('name')}</label>
-						<d2l-input-text autocomplete="off" id="recordName" required value="${this.record && this.record.Name || ''}"></d2l-input-text>
+						<d2l-input-text autocomplete="off" id="recordName" required value="${this.record && this.record.Name || ''}" novalidate></d2l-input-text>
 					</li>
 					<li>
 						<ul class="innerList">
@@ -308,11 +308,11 @@ class AddCpdRecord extends BaseMixin(LitElement) {
 							<div class="credit-time-container">
 								<div>
 									<label for="creditHours" class="d2l-label-text">${this.localize('creditHours')}</label>
-									<d2l-input-text class="numberInput" id="creditHours" required placeholder=${this.localize('enterCreditHours')} type="number" min="0" value="${this.record && getHours(this.record.CreditMinutes) || ''}"></d2l-input-text>
+									<d2l-input-text class="numberInput" id="creditHours" required placeholder=${this.localize('enterCreditHours')} type="number" min="0" value="${this.record && getHours(this.record.CreditMinutes) || ''}" novalidate></d2l-input-text>
 								</div>
 								<div>
 									<label for="creditMinutes" class="d2l-label-text">${this.localize('creditMinutes')}</label>
-									<d2l-input-text class="numberInput" id="creditMinutes" required placeholder=${this.localize('enterCreditMinutes')} type="number" min="0" max="59"  value="${this.record && getMinutes(this.record.CreditMinutes) || ''}"></d2l-input-text>
+									<d2l-input-text class="numberInput" id="creditMinutes" required placeholder=${this.localize('enterCreditMinutes')} type="number" min="0" max="59"  value="${this.record && getMinutes(this.record.CreditMinutes) || ''}" novalidate></d2l-input-text>
 								</div>
 							</div>
 							${this.record && this.record.Grade ? html`

--- a/src/components/cpd-manage-targets.js
+++ b/src/components/cpd-manage-targets.js
@@ -160,6 +160,7 @@ class ManageCpdTargets extends BaseMixin(LitElement) {
 									required type="number"
 									min="0"
 									value="${getHours(this.dialogData.StructuredMinutes)}"
+									novalidate
 								>
 								</d2l-input-text>
 								<label for="structuredMinutes">${this.localize('minutes')}</label>
@@ -171,6 +172,7 @@ class ManageCpdTargets extends BaseMixin(LitElement) {
 									min="0"
 									max="59"
 									value="${getMinutes(this.dialogData.StructuredMinutes)}"
+									novalidate
 								>
 								</d2l-input-text>
 							</div>
@@ -187,6 +189,7 @@ class ManageCpdTargets extends BaseMixin(LitElement) {
 									type="number"
 									min="0"
 									value="${getHours(this.dialogData.UnstructuredMinutes)}"
+									novalidate
 								>
 								</d2l-input-text>
 								<label for="unstructuredMinutes">${this.localize('minutes')}</label>
@@ -199,6 +202,7 @@ class ManageCpdTargets extends BaseMixin(LitElement) {
 									min="0"
 									max="59"
 									value="${getMinutes(this.dialogData.UnstructuredMinutes)}"
+									novalidate
 								>
 								</d2l-input-text>
 							</div>


### PR DESCRIPTION
**Context:**
`d2l-input-text` is getting live validation so it can validate itself. To prevent this from impacting places that have their own validation we're adding `novalidate`. This will keep the behavior unchanged.